### PR TITLE
Project expansion orphans

### DIFF
--- a/controllers/manage.py
+++ b/controllers/manage.py
@@ -5,19 +5,19 @@ import io
 def teaching_staff():
     """Presents a view of teaching staff. 
     
-    Timetablers can add and edit, Admin also delete
+    Timetablers can add and edit
     """
     
     db.teaching_staff.id.readable = False
     
-    is_admin = auth.has_membership('admin')
-    is_timetabler= auth.has_membership('timetabler')
+    can_amend = auth.has_membership('timetabler') or auth.has_membership('admin')
     
     form = SQLFORM.grid(db.teaching_staff,
-                        create=is_timetabler | is_admin,
-                        editable=is_timetabler | is_admin,
-                        deletable=is_admin, 
-                        csv=is_admin)
+                        create=  can_amend ,
+                        editable= can_amend ,
+                        deletable=False, 
+                        csv= can_amend ,
+                        ignore_common_filters= can_amend )
     
     return dict(form=form)
 

--- a/controllers/timetabler.py
+++ b/controllers/timetabler.py
@@ -21,25 +21,6 @@ def overview():
 ## - These can all be viewed by anyone but you have to log in to edit
 ##   and many are locked down to admin staff only
 
-def teaching_staff_table():
-    """Presents a view of teaching staff. 
-    
-    Timetablers can add and edit, Admin delete
-    """
-    
-    db.teaching_staff.id.readable = False
-    
-    is_admin = auth.has_membership('admin')
-    is_timetabler= auth.has_membership('timetabler')
-    
-    form = SQLFORM.grid(db.teaching_staff,
-                        create=is_timetabler,
-                        editable=is_timetabler,
-                        deletable=is_admin, 
-                        csv=is_admin)
-    
-    return dict(form=form)
-
 
 def locations_table():
     """Presents a view of teaching staff. 

--- a/models/shared_tables.py
+++ b/models/shared_tables.py
@@ -39,18 +39,21 @@ db.define_table('email_log',
 #   that doesn't rely on having a second device and we're not in a position to do that.
 ## --------------------------------------------------------------------------------
 
-db.define_table('teaching_staff',
-                # Field('title', 'string'),
-                Field('first_name', 'string', notnull=True),
-                Field('last_name', 'string', notnull=True),
-                Field('institution', 'string'),
-                Field('email', 'string', requires=IS_EMAIL(), notnull=True, unique=True),
-                Field('phone', 'string'),
-                Field('specialisation', 'text'),
-                Field('is_internal', 'boolean', default=True),
-                Field('can_supervise', 'boolean', default=True),
-                format = lambda row: f" {row.last_name}, {row.first_name}")
-
+db.define_table(
+      'teaching_staff',
+      # Field('title', 'string'),
+      Field('first_name', 'string', notnull=True),
+      Field('last_name', 'string', notnull=True),
+      Field('institution', 'string'),
+      Field('email', 'string', requires=IS_EMAIL(), notnull=True, unique=True),
+      Field('phone', 'string'),
+      Field('specialisation', 'text'),
+      Field('is_internal', 'boolean', default=True),
+      Field('can_supervise', 'boolean', default=True),
+      Field('is_active', 'boolean', default=True),
+      format = lambda row: f" {row.last_name}, {row.first_name}",
+      common_filter = lambda query: db.teaching_staff.is_active == True
+)
 
 db.define_table('magic_links',
                 Field('staff_id','reference teaching_staff'),

--- a/views/manage/teaching_staff.html
+++ b/views/manage/teaching_staff.html
@@ -1,3 +1,33 @@
 {{extend 'layout.html'}}
 
+<h1>
+    Teaching staff
+</h1>
+
+<p>
+    This table shows all of the staff that have ever been associated with Masters
+    teaching, project supervision or marking. You can edit staff members to update
+    email addresses - people often carry on working with us after changing institution -
+    and any other details.
+
+    There are three flags associated with teaching staff:
+
+    <ul>
+        <li><strong>Can Supervise</strong>: Only staff with this flag set are allowed to
+        create, advertise and then supervise research projects.
+
+        </li>
+        <li><strong>Is Internal</strong>: Only staff with  this flag set can sole
+        supervise research projects. External supervisors must have an internal
+        supervisor supporting the project.
+        </li>
+        <li><strong>Is Active</strong>: You <strong>cannot delete</strong> members of
+        staff - they will likely be associated with previous teaching and marking in the
+        database - but you can mark them as inactive, which will hide them from view for
+        most users.
+        </li>
+
+    </ul>
+
+
 {{=form}}

--- a/views/wiki/manage_wikimedia.html
+++ b/views/wiki/manage_wikimedia.html
@@ -21,5 +21,4 @@ media file will need a slug, which is used to link to the file in wiki pages.
 </ul>
 
 
-{{pass}}
 {{=grid}}


### PR DESCRIPTION
This PR pulls in a few minor fixes that got orphaned on @davidorme's local machine when `project_expansion` got merged into `develop` on GH.

* Adds some view explanation text.
* Makes it possible to make teaching staff inactive without _deleting_ them from the DB (which cascades a bunch of deletions).