### PR TITLE
Fixing marker roles issues

### DIFF
--- a/views/marking/marking_roles.html
+++ b/views/marking/marking_roles.html
@@ -9,6 +9,13 @@
 	unique marking role name to the marking criteria and a JSON file containing a
 	definition of the form to be used in marking for the role.
 </p>
+<p>
+	To create a new marker role, follow
+	<a href="{{=URL('marking', 'marking_role_details')}}">this link</a>,
+	but note that creating a new role usually requires the creation of a new form
+	definition.
+
+</p>
 
 
 {{=form}}


### PR DESCRIPTION
The previous PR did not handle the different cases for `marker_form_details` properly. For amended roles, the `form_file` variable is read only and not included in the request form variables, so that needs handling in the validation and then the DB insert. Also some minor tweaks to redirects and view text.